### PR TITLE
set_train_params inherit from base model

### DIFF
--- a/network/dlinknet.py
+++ b/network/dlinknet.py
@@ -109,9 +109,3 @@ class DLinkNet(base_model.Base):
         # part b and c: center dilation + decoder
         ftr = self.decoder(ftr, layers, input_size)
         return ftr
-
-    def set_train_params(self, learn_rate, **kwargs):
-        return [
-            {'params': self.encoder.parameters(), 'lr': learn_rate[0]},
-            {'params': self.decoder.parameters(), 'lr': learn_rate[1]}
-        ]

--- a/network/pspnet.py
+++ b/network/pspnet.py
@@ -96,12 +96,6 @@ class PSPNet(base_model.Base):
         pred = self.decoder(ftr)
         return pred
 
-    def set_train_params(self, learn_rate, **kwargs):
-        return [
-            {'params': self.encoder.parameters(), 'lr': learn_rate[0]},
-            {'params': self.decoder.parameters(), 'lr': learn_rate[1]}
-        ]
-
 
 if __name__ == '__main__':
     vgg16 = PSPNet(2, encoder_name='resnet152')

--- a/network/unet.py
+++ b/network/unet.py
@@ -165,12 +165,6 @@ class UNet(base_model.Base):
         pred = self.decoder(ftr, layers)
         return pred
 
-    def set_train_params(self, learn_rate, **kwargs):
-        return [
-            {'params': self.encoder.parameters(), 'lr': learn_rate[0]},
-            {'params': self.decoder.parameters(), 'lr': learn_rate[1]}
-        ]
-
 
 if __name__ == '__main__':
     from network import network_utils


### PR DESCRIPTION
Now base_model has set_train_params that set lr for decoder and encoder
All segmentation networks inherit this function