### PR TITLE
fix import issue

### DIFF
--- a/network/backbones/squeezenet.py
+++ b/network/backbones/squeezenet.py
@@ -13,8 +13,10 @@ from collections import OrderedDict
 import torch
 import torch.nn as nn
 import torch.nn.init as init
-from torch.hub import load_state_dict_from_url
-from torch.utils import model_zoo
+try:
+    from torch.hub import load_state_dict_from_url
+except ImportError:
+    from torch.utils.model_zoo import load_url as load_state_dict_from_url
 
 # Own modules
 # from network import network_utils


### PR DESCRIPTION
_torch.hub_ does not work on some older torch versions
Reference: https://github.com/pytorch/vision/blob/master/torchvision/models/utils.py