### PR TITLE
update config file after command line parameters overwrites cfg

### DIFF
--- a/train.py
+++ b/train.py
@@ -144,7 +144,7 @@ def main():
     misc_utils.set_random_seed(cfg['random_seed'])
     # make training directory
     misc_utils.make_dir_if_not_exist(cfg['save_dir'])
-    shutil.copyfile(cfg['config'], os.path.join(cfg['save_dir'], 'config.json'))
+    misc_utils.save_file(os.path.join(cfg['save_dir'], 'config.json'), cfg)
 
     # train the model
     train_model(cfg, device, parallel)


### PR DESCRIPTION
Save the updated configuration dictionary instead of simply copying the original configuration file. Since now the user can use the command line to overwrite settings in the configuration file, therefore the original configuration file might be outdated.