### PR TITLE
fix multi gpu loading issue

### DIFF
--- a/evaluate.py
+++ b/evaluate.py
@@ -32,7 +32,7 @@ def main():
     if LOAD_EPOCH:
         args['trainer']['epochs'] = LOAD_EPOCH
     ckpt_dir = os.path.join(MODEL_DIR, 'epoch-{}.pth.tar'.format(args['trainer']['epochs']))
-    network_utils.load(model, ckpt_dir, disable_parallel=True)
+    network_utils.load(model, ckpt_dir)
     print('Loaded from {}'.format(ckpt_dir))
     model.to(device)
     model.eval()

--- a/train.py
+++ b/train.py
@@ -54,8 +54,9 @@ def train_model(args, device, parallel):
     except (RuntimeError, TypeError, AttributeError):
         print('Warning: could not write graph to tensorboard, this might be a bug in tensorboardX')
     if parallel:
-        model.encoder = nn.DataParallel(model.encoder)
-        model.decoder = nn.DataParallel(model.decoder)
+        # model.encoder = nn.DataParallel(model.encoder)
+        # model.decoder = nn.DataParallel(model.decoder)
+        model = network_utils.DataParallelPassThrough(model)
         if args['optimizer']['aux_loss']:
             model.cls = nn.DataParallel(model.cls)
         print('Parallel training mode enabled!')


### PR DESCRIPTION
Fix the multi gpu loading issue:
now when training the model with multiple gpus, the whole model instead of encoder and decoder sperately will be wrapped by nn.DataParallel. A pass through function has been defined for DataParallel to expose the customized model attributes.

When loading the model, will try to wrap the model with DataParallel if `disable_parallel=False` and a ValueError has raised. 

Therefore, please **do not** use `disable_parallel=True` when loading the model in evaluate.py