### PR TITLE
Fix eval_utils.display_group()

### DIFF
--- a/mrs_utils/eval_utils.py
+++ b/mrs_utils/eval_utils.py
@@ -41,7 +41,7 @@ def display_group(reg_groups, size, img=None, need_return=False):
     for cnt, group in enumerate(reg_groups):
         for g in group:
             coords = np.array(g.coords)
-            group_map[coords[:, 0], coords[:, 1]] = cnt
+            group_map[coords[:, 0], coords[:, 1]] = cnt + 1
     if need_return:
         return group_map
     else:


### PR DESCRIPTION
At line 44, the value of a foreground pixel starts from 0. In this way, pixels of the first group from reg_groups will be all 0 and will blend in the background since values of background pixels are all 0 too. Change to start the value to give from 1 so all foreground pixels have different values from background pixels.