### PR TITLE
Force read resume_epoch as int & save actually used mean & std in model config.json

### DIFF
--- a/network/network_utils.py
+++ b/network/network_utils.py
@@ -99,10 +99,10 @@ def load_epoch(save_dir, resume_epoch, model, optm, device, model_key='state_dic
     :return:
     """
     checkpoint = torch.load(
-        os.path.join(save_dir, 'epoch-' + str(resume_epoch) + '.pth.tar'),
+        os.path.join(save_dir, 'epoch-' + str(int(resume_epoch)) + '.pth.tar'),
         map_location=lambda storage, loc: storage)  # Load all tensors onto the CPU
     print("Initializing weights from: {}...".format(
-        os.path.join(save_dir, 'epoch-' + str(resume_epoch) + '.pth.tar')))
+        os.path.join(save_dir, 'epoch-' + str(int(resume_epoch)) + '.pth.tar')))
     model.load_state_dict(checkpoint[model_key])
     load_optim(optm, checkpoint['opt_dict'], device)
 


### PR DESCRIPTION
Did two things:
1. Save mean & std that's actually used for transformation/normalization in model's config.json, rather than saving the default values stored in training config file (which most likely will be overridden in training). 
2. fix #55 